### PR TITLE
Add v4.0.2 on s390x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: daadb32f19fe818cb9b0015243233fc81584844c11a48436385e87c050346559  # [win]
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: True  # [unix]
 
 requirements:


### PR DESCRIPTION
`tbb 2021.4.0` requires` swig >=3.0.6` on `s390x` platform

Category:  other | subcategory:   | pkg_type:  library
Popularity:  295288 downloads -  swig  4.0.2  C/C++ parser code generator
  license: GPL 3
Bug Tracker: new open issues https://github.com/swig/swig/issues
Github releases:  https://github.com/swig/swig/releases
License file:  https://github.com/swig/swig/blob/master/LICENSE
Upstream Changelog: https://github.com/swig/swig/blob/master/CHANGES
Upstream install notes: http://swig.org/svn.html

The package swig is mentioned inside the packages:
llvm-compilers | nlopt | svn |  tbb | tbb-2020.01 | tensorflow-base | tensorflow-gpu-base | waf |

Actions:
1. Bump build number

Result:
- all-succeeded